### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/.github/workflows/01-2_SonarQube.yaml
+++ b/.github/workflows/01-2_SonarQube.yaml
@@ -3,6 +3,9 @@ name: 01-2 - Integration SonarQube
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   QualityBack:
     runs-on: ubuntu-latest

--- a/backend/api/routes/cocktail_r.js
+++ b/backend/api/routes/cocktail_r.js
@@ -2,9 +2,17 @@
 const express = require('express')
 const cocktailCtrl = require('../controllers/cocktail_c')
 const checkToken = require('../middleware/checkJwt')
+const rateLimit = require('express-rate-limit')
 
 /*** EEXPRESS ROUTER */
 let router = express.Router()
+
+/*** RATE LIMITER CONFIGURATION */
+const deleteCocktailLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10, // max 10 requests per windowMs
+    message: "Too many delete requests from this IP, please try again later."
+});
 
 /*** COCKTAIL ROUTAGE */
 router.get('/', cocktailCtrl.getAllCocktails)
@@ -13,6 +21,6 @@ router.get('/:id([0-9]+)', cocktailCtrl.getCocktail)
 router.put('/', checkToken, cocktailCtrl.addCocktail)
 router.patch('/:id([0-9]+)', checkToken, cocktailCtrl.modifyCocktail)
 
-router.delete('/:id([0-9]+)', checkToken, cocktailCtrl.deleteCocktail)
+router.delete('/:id([0-9]+)', checkToken, deleteCocktailLimiter, cocktailCtrl.deleteCocktail)
 
 module.exports = router

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.9.7",
-        "sequelize": "^6.37.3"
+        "sequelize": "^6.37.3",
+        "express-rate-limit": "^7.5.0"
     },
     "devDependencies": {
         "jest": "^29.7.0",


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLaclef/DemoDocker/security/code-scanning/17](https://github.com/DavidLaclef/DemoDocker/security/code-scanning/17)

To fix the issue, we need to introduce rate limiting to the `deleteCocktail` route. The best way to achieve this is by using the `express-rate-limit` package, which is a well-known middleware for rate limiting in Express applications. This package allows us to define a maximum number of requests that can be made to a specific route within a given time window.

Steps to implement the fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter configuration for the `deleteCocktail` route.
4. Apply the rate limiter middleware to the `deleteCocktail` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
