### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01-2_SonarQube.yaml
+++ b/.github/workflows/01-2_SonarQube.yaml
@@ -3,6 +3,9 @@ name: 01-2 - Integration SonarQube
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   QualityBack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLaclef/DemoDocker/security/code-scanning/1](https://github.com/DavidLaclef/DemoDocker/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the jobs. Since the workflow primarily interacts with repository contents and artifacts, the `contents: read` permission is sufficient. This block can be added at the root level of the workflow to apply to all jobs or within each job to define permissions individually.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow to set `contents: read` for all jobs.
2. Ensuring no unnecessary permissions are granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
